### PR TITLE
Fix extension being completely broken due to URL changes

### DIFF
--- a/extension/injected.js
+++ b/extension/injected.js
@@ -24,7 +24,7 @@ window.Worker = class Worker extends oldWorker {
 
             ${ functions }
 
-            importScripts('https://static.twitchcdn.net/assets/wasmworker.min-${version}.wasm');
+            importScripts('https://static.twitchcdn.net/assets/wasmworker.min-${version}.js');
         `
         super(URL.createObjectURL(new Blob([newBlobStr])));
     }

--- a/extension/injected.js
+++ b/extension/injected.js
@@ -18,13 +18,13 @@ window.Worker = class Worker extends oldWorker {
 
         var newBlobStr = `
             var Module = {
-                WASM_BINARY_URL: 'https://cvp.twitch.tv/${version}/wasmworker.min.wasm',
+                WASM_BINARY_URL: 'https://static.twitchcdn.net/assets/wasmworker.min-${version}.wasm',
                 WASM_CACHE_MODE: true
             }
 
             ${ functions }
 
-            importScripts('https://cvp.twitch.tv/${version}/wasmworker.min.js');
+            importScripts('https://static.twitchcdn.net/assets/wasmworker.min-${version}.wasm');
         `
         super(URL.createObjectURL(new Blob([newBlobStr])));
     }

--- a/extension/lib.js
+++ b/extension/lib.js
@@ -42,9 +42,10 @@ function getFuncsForInjection (usePerformanceFix) {
                 // So let's reuse the last stream chunk. This will most likely buffer/be glitchy.
                 // We manually increase the sequence number.
                 // TODO: Find better solution?
-                textStr = self._lastStreamChunk;
                 if (textStr === undefined) {
                     textStr = '';
+                } else if (self._lastStreamChunk !== undefined) {
+                textStr = self._lastStreamChunk;
                 }
                 var currSeq = parseInt(getSeqNr(textStr));
                 if (self._lastSeq === undefined) {

--- a/extension/lib.js
+++ b/extension/lib.js
@@ -224,5 +224,5 @@ function getWasmBinaryVersion (twitchBlobUrl) {
     var req = new XMLHttpRequest();
     req.open('GET', twitchBlobUrl, false);
     req.send();
-    return req.responseText.match(/tv\/(.*)\/wasmworker/)[1];
+    return req.responseText.match(/wasmworker\.min\-(.*)\.js/)[1];
 }

--- a/extension/lib.js
+++ b/extension/lib.js
@@ -17,7 +17,7 @@ function getFuncsForInjection (usePerformanceFix) {
     }
 
     function stripAds (textStr) {
-        var haveAdTags = textStr.includes('#EXT-X-SCTE35-OUT');
+        var haveAdTags = textStr.includes('#EXT-X-SCTE35-OUT') || textStr.includes('stitched-ad');
 
         if (haveAdTags) {
             self._wasAd = true;


### PR DESCRIPTION
The current master branch is out of date and prevents Twitch streams from playing entirely when installed. This hotfix updates asset URLs to maintain compatibility.

Resolves #18 