### PR TITLE
Add new ad chunk definition

### DIFF
--- a/extension/lib.js
+++ b/extension/lib.js
@@ -28,6 +28,7 @@ function getFuncsForInjection (usePerformanceFix) {
 
             textStr = textStr.replace(/#EXT-X-SCTE35-OUT(.|\s)*#EXT-X-SCTE35-IN/gmi, '');
             textStr = textStr.replace(/#EXT-X-SCTE35-OUT(.|\s)*/gmi, '');
+            textStr = textStr.replace(/#EXTINF:2.00[12](.|\s)*/gmi, '');
             textStr = textStr.replace(/#EXT-X-SCTE35-IN/gi, '');
             textStr = textStr.replace(/#EXT-X-DISCONTINUITY/gi, '');
             textStr = textStr.replace(/#EXT-X-DATERANGE:ID="stitched-ad.*/gi, '');

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Twitch-HLS-Ad-Block",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "author": "InstanceLabs",
     "description": "Block Twitch ads that are inserted directly in the HLS stream",
     "content_scripts": [{


### PR DESCRIPTION
Some users are seeing a new format for ad chunks that needs to be removed now.
 `#EXTINF:2.001` or `#EXTINF:2.002` vs `#EXTINF:2.000,live` for stream chunks
