### PR TITLE
Adjust for different wasm worker filename.

### DIFF
--- a/extension/injected.js
+++ b/extension/injected.js
@@ -4,7 +4,8 @@ const SUPPORTED_VERSION = "2.9.1";
 const oldWorker = window.Worker;
 window.Worker = class Worker extends oldWorker {
     constructor(twitchBlobUrl) {
-        var version = getWasmBinaryVersion(twitchBlobUrl);
+        var jsURL = getWasmWorkerUrl(twitchBlobUrl);
+        var version = jsURL.match(/wasmworker\.min\-(.*)\.js/)[1];
         var usePerformanceFix = true;
 
         if (version != SUPPORTED_VERSION) {
@@ -18,14 +19,15 @@ window.Worker = class Worker extends oldWorker {
 
         var newBlobStr = `
             var Module = {
-                WASM_BINARY_URL: 'https://static.twitchcdn.net/assets/wasmworker.min-${version}.wasm',
+                WASM_BINARY_URL: '${jsURL.replace('.js', '.wasm')}',
                 WASM_CACHE_MODE: true
             }
 
             ${ functions }
 
-            importScripts('https://static.twitchcdn.net/assets/wasmworker.min-${version}.js');
+            importScripts('${jsURL}');
         `
         super(URL.createObjectURL(new Blob([newBlobStr])));
     }
 }
+

--- a/extension/lib.js
+++ b/extension/lib.js
@@ -222,9 +222,9 @@ function getFuncsForInjection (usePerformanceFix) {
     `
 }
 
-function getWasmBinaryVersion (twitchBlobUrl) {
+function getWasmWorkerUrl (twitchBlobUrl) {
     var req = new XMLHttpRequest();
     req.open('GET', twitchBlobUrl, false);
     req.send();
-    return req.responseText.match(/wasmworker\.min\-(.*)\.js/)[1];
+    return req.responseText.split("'")[1]
 }


### PR DESCRIPTION
It appears to be like https://static.twitchcdn.net/assets/amazon-ivs-wasmworker.min-da256e85d72f42da0b0f.js now, it has a "amazon-ivs-" prefix, the existing URL is giving a 404
back. I adapted the injector to not construct as much of the URL anymore.